### PR TITLE
Add ASDF system definition

### DIFF
--- a/ht-routes.asd
+++ b/ht-routes.asd
@@ -1,0 +1,9 @@
+(asdf:defsystem #:ht-routes
+  :serial t
+  :depends-on (#:cl-ppcre #:hunchentoot)
+  :components ((:file "ht-routes")))
+
+(asdf:defsystem #:ht-routes-test
+  :serial t
+  :depends-on (#:ht-routes #:rt)
+  :components ((:file "test")))

--- a/test.lisp
+++ b/test.lisp
@@ -1,6 +1,3 @@
-;; test using rt
-(ql:quickload :rt)
-(load "ht-routes.lisp")
 (in-package :ht-routes)
 
 (defvar route1 '("/" :get index))


### PR DESCRIPTION
I added two ASDF system definitions, to get rid of (load "ht-routes.lisp") and instead allow loading the library using Quicklisp.
